### PR TITLE
Swapped out uuid for patched version

### DIFF
--- a/server.go
+++ b/server.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/satori/go.uuid"
+	uuid "github.com/gofrs/uuid"
 )
 
 const (


### PR DESCRIPTION
There is an issue with the uuid package being used here, the owner of github.com/satori/go.uuid seems to be inactive so the repo appears to have been forked and fixed into github.com/gofrs/uuid.

This PR is just to swap out the two, full details here https://github.com/satori/go.uuid/issues/73